### PR TITLE
Add lag option

### DIFF
--- a/CommCareAPIHandler.py
+++ b/CommCareAPIHandler.py
@@ -1,6 +1,6 @@
 import boto3
 from botocore.exceptions import ClientError
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import requests
 from const import CASE
@@ -11,7 +11,7 @@ main_bucket_name = 'commcare-snowflake-data-sync'
 s3 = boto3.client('s3')
 
 class CommCareAPIHandler:
-    def __init__(self, domain, api_token_for_domain, event_time, request_limit=100, custom_date_range_config=None, test_mode=False):
+    def __init__(self, domain, api_token_for_domain, event_time, request_limit=100, custom_date_range_config=None, test_mode=False, use_lag=False):
         self.domain = domain
         self.api_token = api_token_for_domain
         self.event_time = event_time
@@ -47,6 +47,12 @@ class CommCareAPIHandler:
 
 
 class CommCareAPIHandlerPull(CommCareAPIHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if kwargs['use_lag']:
+            self.event_time = self.event_time - timedelta(hours=0, minutes=5)
+            print("Added a 5 minute lag.")
 
     def filepath(self, data_type):
         path_beginning = f"{self.domain}/snowflake-copy/"

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -40,18 +40,20 @@ def lambda_handler(event, context):
 
         # Custom date range processing
         if 'custom_date_range' in event:
+            use_lag = False
             custom_date_range_config = event['custom_date_range']
             custom_date_range_tuple = DateRangeTuple(datetime.strptime(custom_date_range_config['start_time'], "%Y-%m-%dT%H:%M:%S.%fZ"),
                 datetime.strptime(custom_date_range_config['end_time'], "%Y-%m-%dT%H:%M:%S.%fZ"))
             print(f"Specific date range specified. Details: {custom_date_range_tuple}")
         else:
+            use_lag = event.get('use_lag') != 0
             custom_date_range_tuple = None
         
         if 'api_info' not in event:
             return err('api_details was missing in event data.')
     
         CommCareAPIHandlerPull(domain, api_token_for_domain, event_time, request_limit=1000,
-            custom_date_range_config=custom_date_range_tuple, test_mode=test_mode).pull_data_for_domain(event['api_info'])
+            custom_date_range_config=custom_date_range_tuple, test_mode=test_mode, use_lag=use_lag).pull_data_for_domain(event['api_info'])
         
         print(f"Data pull for domain: {domain} finished.")
         return {


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/UDA-1912

Adds a 5-minute lag in the Lambda function's execution. See ticket for details.

This turns it on by default, but you can turn it off with the event data (passed from Eventbridge) parameter:

`use_lag: 0`