### PR TITLE
Automatic API limit

### DIFF
--- a/CommCareAPIHandler.py
+++ b/CommCareAPIHandler.py
@@ -138,7 +138,6 @@ class CommCareAPIHandlerPull(CommCareAPIHandler):
             if response_data['meta']['next']:
                 if data_type.get('uses_indexed_on'):
                     limit = response_data['meta']['limit']
-                    assert data_type['limit'] == limit
                     last_item = response_data['objects'][limit - 1]
                     try:
                         request_end_boundary = datetime.strptime(last_item['indexed_on'], "%Y-%m-%dT%H:%M:%S.%fZ").isoformat()

--- a/Testing/tests_CommCareAPIHandler.py
+++ b/Testing/tests_CommCareAPIHandler.py
@@ -41,6 +41,7 @@ class TestCommCareAPIHandler(unittest.TestCase):
             {
                 'name': 'test_default_init',
                 'api': CommCareAPIHandler(
+                    False,
                     'test_domain',
                     'test_domain-api-key',
                     datetime.strptime(
@@ -64,6 +65,7 @@ class TestCommCareAPIHandler(unittest.TestCase):
             {
                 'name': 'test_custom_init',
                 'api': CommCareAPIHandler(
+                    False,
                     'test_domain',
                     'test_domain-api-key',
                     datetime.strptime(
@@ -104,6 +106,7 @@ class TestCommCareAPIHandler(unittest.TestCase):
             {
                 'name': 'test_default_api_base_url',
                 'api': CommCareAPIHandler(
+                    False,
                     'test_domain',
                     'test_domain-api-key',
                     datetime.strptime(
@@ -141,6 +144,7 @@ class TestCommCareAPIHandler(unittest.TestCase):
             {
                 'name': 'test_under_api_error_threshold',
                 'api': CommCareAPIHandler(
+                    False,
                     'test_domain',
                     'test_domain-api-key',
                     datetime.strptime(
@@ -156,6 +160,7 @@ class TestCommCareAPIHandler(unittest.TestCase):
             {
                 'name': 'test_above_api_error_threshold',
                 'api': CommCareAPIHandler(
+                    False,
                     'test_domain',
                     'test_domain-api-key',
                     datetime.strptime(

--- a/Testing/tests_CommCareAPIHandlerPush.py
+++ b/Testing/tests_CommCareAPIHandlerPush.py
@@ -69,6 +69,7 @@ class TestCommCareAPIHandlerPush(unittest.TestCase):
     def __init__(self, methodName):
         super().__init__(methodName)
         self.api = CommCareAPIHandlerPush(
+            False,
             'test_domain',
             'test_domain-api-key',
             datetime.strptime(

--- a/Testing/tests_util.py
+++ b/Testing/tests_util.py
@@ -85,7 +85,7 @@ class TestUtil(unittest.TestCase):
                 'return_value': None,
                 'expect_exception': True,
                 'exception': util.APIError(
-                    "Request failed! Code: 400. Reason: Test", 400)
+                    "Request failed! Code: 400. Reason: Test. Details: {}", 400)
             }
         ]
 

--- a/util.py
+++ b/util.py
@@ -1,4 +1,7 @@
 import boto3
+import json
+import requests
+
 from requests.exceptions import JSONDecodeError
 ssm_client = boto3.client('ssm')
 
@@ -36,3 +39,47 @@ def get_api_token(domain, specifier=None):
 def put_value_parameter_store(param_name, param_value, overwrite=False):
     response = ssm_client.put_parameter(Name=param_name, Value=param_value, Overwrite=overwrite)
     process_response(response, is_boto=True)
+
+class APILimitCalculator(object):
+
+    """
+        This class helps CommCareAPIHandlerPull calcluate API limits for data types with an
+        automatically-determined API limit (set via the "auto_determine_limit" parameter
+        in the event payload).
+    """
+
+    # Snowflake pipeline can only handle file sizes 16MB or less
+    max_file_size_in_mb = 16
+    # File sizes often vary in size due to natural variety in size of cases, forms, etc. This offset
+    #   provides room for instances where there are coincidentally large cases or forms in the request.
+    file_size_grace_offset = 0.50
+    # The maximum limit prevents calculated limits from being inappropriately high.
+    max_limit = 10000
+
+    @classmethod
+    def determine_new_api_limit(cls, current_limit, size_of_test_request_in_bytes):
+        """
+            Calculates the appropriate API limit for this data type, based on the file size of
+            a test request made to the API.
+        """
+        size_in_mb = size_of_test_request_in_bytes / 1000000
+        print(f"Calculated file size with current limit to be: {size_in_mb}MB.")
+        calculated_new_limit = cls.calculate_new_api_limit(size_in_mb, current_limit)
+        if calculated_new_limit < cls.max_limit:
+            print(f"New appropriate limit calculated to be: {calculated_new_limit}.")
+            return calculated_new_limit
+        else:
+            print(f"New calculated limit was above the maximum ({cls.max_limit}). Using max limit instead...")
+            return cls.max_limit
+
+    @classmethod
+    def calculate_new_api_limit(cls, size_in_mb, current_limit):
+        """
+            Example: if the maximum file size is 16MB, and a request with the current limit to the API returns a
+            file size of 8 MB, the new limit is 16 / 8 * the current limit * the grace offset. The grace
+            offset gives breathing room below the maxiumum file size so that a possibly larger request using the
+            same limit does not go over the maximum file size.
+        """
+        new_appropriate_limit = (cls.max_file_size_in_mb / size_in_mb) * float(current_limit)
+        new_limit = int(new_appropriate_limit * cls.file_size_grace_offset)
+        return new_limit

--- a/util.py
+++ b/util.py
@@ -12,7 +12,7 @@ def process_response(response, is_boto=False):
     # The python requests library is assumed to be default
     if is_boto:
         status_code = response['ResponseMetadata']['HTTPStatusCode']
-        if status_code != 200:
+        if not (200 <= status_code < 300):
             raise Exception(f"Boto3 request failed! Code: {status_code}.")
     elif response.ok:
         return response.json()


### PR DESCRIPTION
Jira: https://dimagi.atlassian.net/browse/UDA-1924?atlOrigin=eyJpIjoiNDI2MWI0ZmY3ODEyNDEyOTg5NGNlMDcxNTFmZTM0MWQiLCJwIjoiaiJ9

Adds two new pieces of functionality:
1. The ability to specify in the event payload that the domain is a staging domain. You can specify `"is_staging": 1` in the payload to automatically use the CCHQ staging URL for requests, so that we do not need to maintain separate lambda code for staging domains.
2. The abilty to tell the function to automatically determine the API limit. Upon each Lambda run, the function will "test" the current stored API limit (stored in a txt file, similar to "last successful run time") and adjust it based on the maximum file size (16 MB) (i.e. make sure it doesn't go over the file size, or isn't drastically low). You can specify `"auto_determine_limit": 1` for a specifc data type to turn this functionality on for that data type.